### PR TITLE
Fix backwards compatability

### DIFF
--- a/python3-job-type/plugin-manifest.yaml
+++ b/python3-job-type/plugin-manifest.yaml
@@ -1,3 +1,3 @@
 name: python3-job-type
-version: 2.6.0
+version: 2.6.1
 url: 'https://github.com/TheRacetrack/plugin-python-job-type'

--- a/python3-job-type/python_wrapper/job_wrapper/api.py
+++ b/python3-job-type/python_wrapper/job_wrapper/api.py
@@ -56,7 +56,7 @@ def create_health_app(health_state: HealthState) -> FastAPI:
 
     setup_health_endpoints(fastapi_app, health_state, job_name)
 
-    return mount_at_base_path(fastapi_app, '/pub/job/{job_name}/{version}')
+    return mount_at_base_path(fastapi_app, '/pub/job/{job_name}/{version}', '/pub/fatman/{job_name}/{version}')
 
 
 def create_api_app(
@@ -94,7 +94,7 @@ def create_api_app(
             'job_version': job_version,
         })
 
-    return mount_at_base_path(fastapi_app, '/pub/job/{job_name}/{version}')
+    return mount_at_base_path(fastapi_app, '/pub/job/{job_name}/{version}', '/pub/fatman/{job_name}/{version}')
 
 
 def _setup_api_endpoints(

--- a/python3-job-type/python_wrapper/tests/wrap/test_perform_endpoint.py
+++ b/python3-job-type/python_wrapper/tests/wrap/test_perform_endpoint.py
@@ -7,9 +7,15 @@ def test_wrapped_endpoints():
 
     client = TestClient(api_app)
 
-    response = client.post(
+    paths = [
         '/api/v1/perform',
-        json={'numbers': [40, 2]},
-    )
-    assert response.status_code == 200
-    assert response.json() == 42
+        '/pub/job/adder/latest/api/v1/perform',
+        '/pub/fatman/adder/latest/api/v1/perform',  # backward compatibility
+    ]
+    for path in paths:
+        response = client.post(
+            path,
+            json={'numbers': [40, 2]},
+        )
+        assert response.status_code == 200
+        assert response.json() == 42


### PR DESCRIPTION
closes #13. 

Now properly backwards compatible with the deprecated fatman naming. 