### PR TITLE
Make chain call function accessible for users

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,13 +4,23 @@ All **user-facing**, notable changes will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [2.8.0] - 2023-05-31
+### Added
+- Chain calls to the jobs can be made by importing the `call_job` function from a package provided by the job type plugin
+  `from job_wrapper.call import call_job`.
+  See the [example](../sample/python-chain/entrypoint.py) and
+  the [function](../python3-job-type/python_wrapper/job_wrapper/call.py) for more details.
 
 ## [2.6.2] - 2023-05-18
 ### Added
 - Setting `LOG_CALLER_NAME: 'true'` env var in a manifest allows you
   to keep record of a caller in the job's logs.
   This will add caller identity (username or ESC name) to every log entry.
+  Exemplary Manifest snippet:
+  ```yaml
+  runtime_env:
+    LOG_CALLER_NAME: 'true'
+  ```
 
 ## [2.5.7] - 2022-12-01
 ### Fixed

--- a/python3-job-type/plugin-manifest.yaml
+++ b/python3-job-type/plugin-manifest.yaml
@@ -1,3 +1,3 @@
 name: python3-job-type
-version: 2.7.0
+version: 2.8.0
 url: 'https://github.com/TheRacetrack/plugin-python-job-type'

--- a/python3-job-type/python_wrapper/job_wrapper/call.py
+++ b/python3-job-type/python_wrapper/job_wrapper/call.py
@@ -1,0 +1,52 @@
+import os
+from typing import Dict, Any, Optional
+
+import httpx
+
+from job_wrapper.entrypoint import JobEntrypoint
+
+
+def call_job(
+    entrypoint: JobEntrypoint,
+    job_name: str,
+    path: str = '/api/v1/perform',
+    payload: Optional[Dict] = None,
+    version: str = 'latest',
+) -> Any:
+    """
+    Call another job's endpoint.
+    :param entrypoint: entrypoint object of the job that calls another job
+    :param job_name: name of the job to call
+    :param path: endpoint path to call, default is /api/v1/perform
+    :param payload: payload to send: dictionary with parameters or None
+    :param version: version of the job to call. Use exact version or alias, like "latest"
+    :return: result object returned by the called job
+    """
+    src_job = os.environ.get('JOB_NAME')
+    try:
+        assert src_job, 'JOB_NAME env var is not set'
+        internal_pub_url = os.environ['PUB_URL']
+        url = f'{internal_pub_url}/job/{job_name}/{version}{path}'
+
+        tracing_header = os.environ.get('REQUEST_TRACING_HEADER', 'X-Request-Tracing-Id')
+        caller_header = os.environ.get('CALLER_NAME_HEADER', 'X-Caller-Name')
+        if hasattr(entrypoint, 'request_context'):
+            request = getattr(entrypoint, 'request_context').get()
+            tracing_id = request.headers.get(tracing_header) or ''
+            caller_name = request.headers.get(caller_header) or ''
+        else:
+            tracing_id = ''
+            caller_name = ''
+
+        r = httpx.post(url, json=payload, headers={
+            'X-Racetrack-Auth': os.environ['AUTH_TOKEN'],
+            tracing_header: tracing_id,
+            caller_header: caller_name,
+        })
+        r.raise_for_status()
+        return r.json()
+
+    except httpx.HTTPStatusError as e:
+        raise RuntimeError(f'failed to call job "{job_name} {version}" by {src_job}: {e}: {e.response.text}') from e
+    except BaseException as e:
+        raise RuntimeError(f'failed to call job "{job_name} {version}" by {src_job}: {e}') from e

--- a/python3-job-type/python_wrapper/requirements-dev.txt
+++ b/python3-job-type/python_wrapper/requirements-dev.txt
@@ -4,4 +4,3 @@ coverage==7.2.1
 backoff==2.2.1
 numpy==1.24.2
 Flask==2.2.5
-httpx==0.23.3

--- a/python3-job-type/python_wrapper/requirements.txt
+++ b/python3-job-type/python_wrapper/requirements.txt
@@ -1,2 +1,3 @@
 PyYAML==6.0
 a2wsgi==1.7.0
+httpx==0.24.0

--- a/sample/python-chain/entrypoint.py
+++ b/sample/python-chain/entrypoint.py
@@ -1,13 +1,12 @@
-import os
-from typing import Dict, Any, List
+from typing import List
 
-import requests
+from job_wrapper.call import call_job
 
 
 class JobEntrypoint:
     def perform(self, numbers: List[float]) -> float:
         """Round result from another model"""
-        partial = self.call_job('python-class', '/api/v1/perform', {'numbers': numbers})
+        partial = call_job(self, 'adder', '/api/v1/perform', {'numbers': numbers})
         return round(partial)
 
     def docs_input_example(self) -> dict:
@@ -15,34 +14,3 @@ class JobEntrypoint:
         return {
             'numbers': [0.2, 0.9],
         }
-
-    def call_job(
-        self,
-        job_name: str,
-        path: str = '/api/v1/perform',
-        payload: Dict = None,
-        version: str = 'latest',
-    ) -> Any:
-        try:
-            src_job = os.environ['JOB_NAME']
-            internal_pub_url = os.environ['PUB_URL']
-            url = f'{internal_pub_url}/job/{job_name}/{version}{path}'
-
-            tracing_header = os.environ.get('REQUEST_TRACING_HEADER', 'X-Request-Tracing-Id')
-            if hasattr(self, 'request_context'):
-                request = getattr(self, 'request_context').get()
-                tracing_id = request.headers.get(tracing_header) or ''
-            else:
-                tracing_id = ''
-
-            r = requests.post(url, json=payload, headers={
-                'X-Racetrack-Auth': os.environ['AUTH_TOKEN'],
-                tracing_header: tracing_id,
-            })
-            r.raise_for_status()
-            return r.json()
-            
-        except requests.HTTPError as e:
-            raise RuntimeError(f'failed to call job "{job_name} {version}" by {src_job}: {e}: {e.response.text}') from e
-        except BaseException as e:
-            raise RuntimeError(f'failed to call job "{job_name} {version}" by {src_job}: {e}') from e


### PR DESCRIPTION
Chain calls to the jobs can be made by importing the `call_job` function from a package provided by the job type plugin
  `from job_wrapper.call import call_job`.

- Keeping this chain call function inside this plugin makes sure it will always be up-to-date with the job type.
- No additional step for updating this function. Job developers update job type version occasionally, then it will get updated too automatically.
- It is Python-related, so it makes sense to keep it not in the Racetrack core, but inside plugin-python-job-type.
- No additional PyPI libs to import
- Drawback: Job developers will have to import from `job_wrapper` library that doesn't exist locally. (Is it really a drawback? It was never available to make chain calls locally)
- racetrack-client tool is no good place for it as it's supposed to be language-agnostic core of the Racetrack