### PR TITLE
Cap the number of concurrent requests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ setup:
 
 setup-install:
 	. venv/bin/activate &&\
-	(cd src/python_wrapper && make setup-install)
+	(cd src/python_wrapper && make setup)
 
 test:
 	(cd src/python_wrapper && make test)

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,16 @@ All **user-facing**, notable changes will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.14.0] - 2024-03-25
+### Added
+- Maximum number of concurrent requests can be limited by `max_concurrency` field in a manifest:
+  ```yaml
+  jobtype_extra:
+    max_concurrency: 1
+  ```
+  By default, concurrent requests are unlimited. Setting `max_concurrency` to `1` will make the job
+  process requests one by one. Overdue requests will be queued and processed in order.
+
 ## [2.13.2] - 2024-02-22
 ### Fixed
 - Use ExceptionGroups from Python 3.11 properly.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -14,6 +14,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   By default, concurrent requests are unlimited. Setting `max_concurrency` to `1` will make the job
   process requests one by one. Overdue requests will be queued and processed in order.
 
+  Having such concurrency limits may cause some requests to wait in a queue.
+  If an average throughput is higher than the job can handle, the queue will grow indefinitely.
+  To prevent that, you can set `jobtype_extra.max_concurrency_queue` to limit the queue size.
+  When the queue is full, the job will return `429 Too Many Requests` status code.
+
+  See the [Python job type](https://github.com/TheRacetrack/plugin-python-job-type/blob/master/docs/job_python3.md)
+
 ## [2.13.2] - 2024-02-22
 ### Fixed
 - Use ExceptionGroups from Python 3.11 properly.

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -15,3 +15,4 @@ This document describes compatibility of the versions of this plugin with the Ra
 | 2.13.0         | `>= 2.26.0`                  |
 | 2.13.1         | `>= 2.26.0`                  |
 | 2.13.2         | `>= 2.26.0`                  |
+| 2.14.0         | `>= 2.26.0`                  |

--- a/docs/job_python3.md
+++ b/docs/job_python3.md
@@ -303,7 +303,7 @@ process requests one by one. Overdue requests will be queued and processed in or
 
 Having such concurrency limits may cause some requests to wait in a queue.
 If a throughput is higher than the job can handle, the queue will grow indefinitely.
-To prevent that, you can set `jobtype_extra.max_concurrency_queue` to limit the queue size.
+To prevent that, you can also set `jobtype_extra.max_concurrency_queue` to limit the queue size.
 When the queue is full, the job will return `429 Too Many Requests` status code.
 
 Example (1 request at a time, with up to 10 requests waiting in a queue):

--- a/docs/job_python3.md
+++ b/docs/job_python3.md
@@ -2,7 +2,7 @@
 "python3" job type is intended to handle the calls to your Python function.
 Racetrack will wrap it up in a web server.
 
-Set `lang: python3:latest` in your `job.yaml` manifest file in order to use this type of job.
+Set `jobtype: python3:latest` in your `job.yaml` manifest file in order to use this type of job.
 
 ## Job standards
 Let's assume you already have your code in a repository at `supersmart/model.py`:
@@ -296,6 +296,15 @@ runtime_env:
 ```
 This will add caller identity (username or ESC name) to every log entry.
 
+### Concurrent requests cap
+Maximum number of concurrent requests can be limited by `max_concurrency` field:
+```yaml
+jobtype_extra:
+  max_concurrency: 1
+```
+By default, concurrent requests are unlimited. Setting `max_concurrency` to `1` will make the job
+process requests one by one. Overdue requests will be queued and processed in order.
+
 ## Summary of principles
 To sum up:
 
@@ -328,16 +337,17 @@ When using `python3` job type, you MUST include the following fields in a `job.y
 
 - `name` - choose a meaningful text name for a job. It should be unique within the Racetrack cluster.
 - `owner_email` - email address of the Job's owner to reach out
-- `lang` - Set base image to "python3"
+- `jobtype` - Set base image to "python3"
 - `git.remote` - URL to your remote repo 
-- `python.entrypoint_path` - Specify relative path to a file with Job Entrypoint class. 
+- `jobtype_extra.entrypoint_path` - Specify relative path to a file with Job Entrypoint class. 
   This file will be imported as a python module when the Job is started. 
   
 You MAY include the following fields:
 
-- `python.requirements_path` - Specify pip requirements.txt location
-- `python.entrypoint_class` - name of Python entrypoint class. 
+- `jobtype_extra.requirements_path` - Specify pip requirements.txt location
+- `jobtype_extra.entrypoint_class` - name of Python entrypoint class. 
   Use it if you want to declare it explicitly. Otherwise, Racetrack will discover that on its own.
+- `jobtype_extra.max_concurrency` (**integer**) - to limit maximum number of concurrent requests.
 
 Check out [The Job Manifest File Schema](https://theracetrack.github.io/racetrack/docs/manifest-schema/) to see all available fields.
 
@@ -345,13 +355,14 @@ The final `job.yaml` may look like this:
 ```yaml
 name: supersmart
 owner_email: nobody@example.com
-lang: python3:latest
+jobtype: python3:latest
 
 git:
   remote: https://github.com/racetrack/supersmart-model
   branch: master
 
-python:
+jobtype_extra:
   requirements_path: 'supersmart/requirements.txt'
   entrypoint_path: 'job_entrypoint.py'
+  max_concurrency: 1
 ```

--- a/docs/job_python3.md
+++ b/docs/job_python3.md
@@ -297,13 +297,21 @@ runtime_env:
 This will add caller identity (username or ESC name) to every log entry.
 
 ### Concurrent requests cap
-Maximum number of concurrent requests can be limited by `max_concurrency` field:
+Maximum number of concurrent requests can be limited by `jobtype_extra.max_concurrency` field:
+By default, concurrent requests are unlimited. Setting `max_concurrency` to `1` will make the job
+process requests one by one. Overdue requests will be queued and processed in order.
+
+Having such concurrency limits may cause some requests to wait in a queue.
+If a throughput is higher than the job can handle, the queue will grow indefinitely.
+To prevent that, you can set `jobtype_extra.max_concurrency_queue` to limit the queue size.
+When the queue is full, the job will return `429 Too Many Requests` status code.
+
+Example (1 request at a time, with up to 10 requests waiting in a queue):
 ```yaml
 jobtype_extra:
   max_concurrency: 1
+  max_concurrency_queue: 10
 ```
-By default, concurrent requests are unlimited. Setting `max_concurrency` to `1` will make the job
-process requests one by one. Overdue requests will be queued and processed in order.
 
 ## Summary of principles
 To sum up:
@@ -348,6 +356,8 @@ You MAY include the following fields:
 - `jobtype_extra.entrypoint_class` - name of Python entrypoint class. 
   Use it if you want to declare it explicitly. Otherwise, Racetrack will discover that on its own.
 - `jobtype_extra.max_concurrency` (**integer**) - to limit maximum number of concurrent requests.
+- `jobtype_extra.max_concurrency_queue` (**integer**) -
+  to limit maximum number of requests waiting in a queue due to concurrency limits.
 
 Check out [The Job Manifest File Schema](https://theracetrack.github.io/racetrack/docs/manifest-schema/) to see all available fields.
 
@@ -365,4 +375,5 @@ jobtype_extra:
   requirements_path: 'supersmart/requirements.txt'
   entrypoint_path: 'job_entrypoint.py'
   max_concurrency: 1
+  max_concurrency_queue: 10
 ```

--- a/sample/python-logging-format/job.yaml
+++ b/sample/python-logging-format/job.yaml
@@ -1,13 +1,13 @@
 name: python-logging-format
 version: 0.0.1
 owner_email: sample@example.com
-lang: python3:latest
+jobtype: python3:latest
 
 git:
   remote: https://github.com/TheRacetrack/plugin-python-job-type
   directory: sample/python-logging-format
 
-python:
+jobtype_extra:
   entrypoint_path: 'entrypoint.py'
   entrypoint_class: 'JobEntrypoint'
 

--- a/src/plugin-manifest.yaml
+++ b/src/plugin-manifest.yaml
@@ -1,4 +1,4 @@
 name: python3-job-type
-version: 2.13.2
+version: 2.14.0
 url: 'https://github.com/TheRacetrack/plugin-python-job-type'
 category: 'job-type'

--- a/src/python_wrapper/racetrack_client/requirements.txt
+++ b/src/python_wrapper/racetrack_client/requirements.txt
@@ -2,5 +2,5 @@ PyYAML >= 6.0
 pydantic >= 2.0
 backoff >= 2.2
 python-socketio[client] >= 5.8
-typer[all] >= 0.7.0
+typer >= 0.7.0
 jsonschema >= 4.17.3

--- a/src/python_wrapper/racetrack_client/utils/quantity.py
+++ b/src/python_wrapper/racetrack_client/utils/quantity.py
@@ -10,7 +10,6 @@ from pydantic import (
 )
 from typing_extensions import Annotated
 
-
 @total_ordering
 class Quantity:
     _suffix_multipliers = {
@@ -25,11 +24,11 @@ class Quantity:
         'u': 1e-6,
         'n': 1e-9,
         'p': 1e-12,
-        'Ei': 1024 ** 6,
-        'Pi': 1024 ** 5,
-        'Ti': 1024 ** 4,
-        'Gi': 1024 ** 3,
-        'Mi': 1024 ** 2,
+        'Ei': 1024**6,
+        'Pi': 1024**5,
+        'Ti': 1024**4,
+        'Gi': 1024**3,
+        'Mi': 1024**2,
         'Ki': 1024,
     }
 
@@ -60,7 +59,7 @@ class Quantity:
 
     def __repr__(self) -> str:
         return self.__str__()
-
+    
     def __bool__(self) -> bool:
         return self.base_number > 0
 
@@ -93,7 +92,7 @@ class Quantity:
 
     @classmethod
     def __get_pydantic_json_schema__(
-            cls, core_schema: core_schema.CoreSchema, handler: GetJsonSchemaHandler
+        cls, core_schema: core_schema.CoreSchema, handler: GetJsonSchemaHandler
     ) -> Dict[str, Any]:
         return {'type': 'string'}
 

--- a/src/python_wrapper/racetrack_job_wrapper/api.py
+++ b/src/python_wrapper/racetrack_job_wrapper/api.py
@@ -306,7 +306,7 @@ def jobtype_extra_int(jobtype_extra: Dict[str, Any], field_name: str) -> Optiona
     str_val = jobtype_extra.get(field_name)
     if str_val is None:
         return None
-    assert str_val.isdigit(), f'Expected integer in {field_name}, but got: {str_val}'
+    assert str(str_val).isdigit(), f'Expected integer in {field_name}, but got: {str_val}'
     return int(str_val)
 
 
@@ -320,7 +320,9 @@ def make_concurrency_runner(options: EndpointOptions) -> Callable[[Callable[...,
     def concurrency_wrapper(f: Callable[..., Any]) -> Any:
         queue_size: int = options.active_requests_counter.value - max_concurrency
         if max_concurrency_queue is not None and queue_size >= max_concurrency_queue:
-            raise HTTPException(503, 'too many requests waiting in a queue')  # Service Unavailable
+            # Too Many Requests
+            raise HTTPException(429, f'too many requests waiting in a queue. Job is set to process {max_concurrency}'
+                                     f' requests concurrently with a queue of max size {max_concurrency_queue}')
         try:
             options.active_requests_counter.inc()
             with concurrency_semaphore:

--- a/src/python_wrapper/racetrack_job_wrapper/api.py
+++ b/src/python_wrapper/racetrack_job_wrapper/api.py
@@ -1,19 +1,22 @@
 import inspect
 import mimetypes
 import os
+import threading
+from dataclasses import dataclass
+
 import time
 from pathlib import Path
 from typing import Any, Callable, Dict, Tuple, Union, Optional
 from contextvars import ContextVar
 
-from fastapi import Body, FastAPI, APIRouter, Request, Response
+from fastapi import Body, FastAPI, APIRouter, Request, Response, HTTPException
 from fastapi.responses import RedirectResponse
 
 from racetrack_job_wrapper.webview import setup_webview_endpoints
+from racetrack_job_wrapper.concurrency import AtomicInteger
 from racetrack_job_wrapper.docs import get_input_example, get_perform_docs
 from racetrack_job_wrapper.entrypoint import (
     JobEntrypoint,
-    perform_entrypoint,
     list_entrypoint_parameters,
     list_auxiliary_endpoints,
     list_static_endpoints,
@@ -39,12 +42,21 @@ from racetrack_commons.telemetry.otlp import setup_opentelemetry
 logger = get_logger(__name__)
 
 
+@dataclass
+class EndpointOptions:
+    api: APIRouter
+    entrypoint: JobEntrypoint
+    jobtype_extra: Dict[str, Any]
+    active_requests_counter: AtomicInteger
+    concurrency_runner: Callable[[Callable[..., Any]], Any] = lambda f: f()
+
+
 def create_health_app(health_state: HealthState) -> FastAPI:
     """
     Create temporary app serving liveness & readiness endpoints until the actual Job entrypoint loads up.
     """
     job_name = os.environ.get('JOB_NAME', '')
-    job_version = os.environ.get('JOB_VERSION')
+    job_version = os.environ.get('JOB_VERSION', '')
     base_url = f'/pub/job/{job_name}/{job_version}'
 
     fastapi_app = create_fastapi(
@@ -68,9 +80,9 @@ def create_api_app(
 ) -> FastAPI:
     """Create FastAPI app and register all endpoints without running a server"""
     job_name = os.environ.get('JOB_NAME', '')
-    job_version = os.environ.get('JOB_VERSION')
+    job_version = os.environ.get('JOB_VERSION', '')
     base_url = f'/pub/job/{job_name}/{job_version}'
-    jobtype_extra: Dict[str, Any] = manifest_dict.get('jobtype_extra', {})
+    jobtype_extra: Dict[str, Any] = manifest_dict.get('jobtype_extra') or {}
     home_page = jobtype_extra.get('home_page') or '/docs'
 
     fastapi_app = create_fastapi(
@@ -90,7 +102,14 @@ def create_api_app(
     setup_metrics_endpoint(fastapi_app)
 
     api_router = APIRouter(tags=['API'])
-    _setup_api_endpoints(api_router, entrypoint, fastapi_app, base_url)
+    options = EndpointOptions(
+        api=api_router,
+        entrypoint=entrypoint,
+        jobtype_extra=jobtype_extra,
+        active_requests_counter=AtomicInteger(0),
+    )
+    options.concurrency_runner = make_concurrency_runner(options)
+    _setup_api_endpoints(api_router, entrypoint, fastapi_app, base_url, options)
     _setup_request_context(entrypoint, fastapi_app)
     fastapi_app.include_router(api_router, prefix="/api/v1")
 
@@ -99,7 +118,7 @@ def create_api_app(
         return RedirectResponse(f"{base_url}{home_page}")
 
     if os.environ.get('OPENTELEMETRY_ENDPOINT'):
-        setup_opentelemetry(fastapi_app, os.environ.get('OPENTELEMETRY_ENDPOINT'), 'job', {
+        setup_opentelemetry(fastapi_app, os.environ.get('OPENTELEMETRY_ENDPOINT', ''), 'job', {
             'job_name': job_name,
             'job_version': job_version,
         })
@@ -112,102 +131,99 @@ def _setup_api_endpoints(
     entrypoint: JobEntrypoint,
     fastapi_app: FastAPI,
     base_url: str,
+    options: EndpointOptions,
 ):
-    _setup_perform_endpoint(api, entrypoint)
-    _setup_auxiliary_endpoints(api, entrypoint)
+    _setup_perform_endpoint(options)
+    _setup_auxiliary_endpoints(options)
     _setup_static_endpoints(api, entrypoint)
     setup_webview_endpoints(entrypoint, base_url, fastapi_app, api)
 
 
-def _setup_perform_endpoint(api: APIRouter, entrypoint: JobEntrypoint):
-    example_input = get_input_example(entrypoint, endpoint='/perform')
-
+def _setup_perform_endpoint(options: EndpointOptions):
+    example_input = get_input_example(options.entrypoint, endpoint='/perform')
     endpoint_path = '/perform'
     summary = "Call main action"
     description = "Call main action"
-    perform_docs = get_perform_docs(entrypoint)
+    perform_docs = get_perform_docs(options.entrypoint)
     if perform_docs:
         description = f"Call main action: {perform_docs}"
 
-    @api.post(
+    @options.api.post(
         '/perform',
         summary=summary,
         description=description,
     )
-    def _perform_endpoint(payload: Dict[str, Any] = Body(default=example_input)):
+    def _perform_endpoint(payload: Dict[str, Any] = Body(default=example_input)) -> Any:
         """Call main action"""
-        metric_requests_started.inc()
-        metric_endpoint_requests_started.labels(endpoint=endpoint_path).inc()
-        start_time = time.time()
-        try:
-            assert payload is not None, 'payload is empty'
-            result = perform_entrypoint(entrypoint, payload)
-            return result
-        except BaseException as e:
-            metric_request_internal_errors.labels(endpoint=endpoint_path).inc()
-            raise e
-        finally:
-            metric_request_duration.labels(endpoint=endpoint_path).observe(time.time() - start_time)
-            metric_requests_done.inc()
-            metric_last_call_timestamp.set(time.time())
+        if not hasattr(options.entrypoint, 'perform'):
+            raise ValueError("entrypoint doesn't have 'perform' method implemented")
+        endpoint_method = options.entrypoint.perform
+        return _call_job_endpoint(endpoint_method, endpoint_path, payload, options)
 
-    @api.get('/parameters')
+    @options.api.get('/parameters')
     def _get_parameters():
         """Return required arguments & optional parameters that model accepts"""
-        return list_entrypoint_parameters(entrypoint)
+        return list_entrypoint_parameters(options.entrypoint)
 
 
-def _setup_auxiliary_endpoints(api: APIRouter, entrypoint: JobEntrypoint):
+def _setup_auxiliary_endpoints(options: EndpointOptions):
     """Configure custom auxiliary endpoints defined by user in an entypoint"""
-    auxiliary_endpoints = list_auxiliary_endpoints(entrypoint)
+    auxiliary_endpoints = list_auxiliary_endpoints(options.entrypoint)
     for endpoint_path in sorted(auxiliary_endpoints.keys()):
 
         endpoint_method: Callable = auxiliary_endpoints[endpoint_path]
         endpoint_name = endpoint_path.replace('/', '_')
-
-        example_input = get_input_example(entrypoint, endpoint=endpoint_path)
-
+        example_input = get_input_example(options.entrypoint, endpoint=endpoint_path)
         if not endpoint_path.startswith('/'):
             endpoint_path = '/' + endpoint_path
 
         # keep these variables inside closure as next loop cycle will overwrite it
-        def _add_endpoint(endpoint_path: str, endpoint_method: Callable):
-
-            summary = f"Call auxiliary endpoint: {endpoint_path}"
+        def _add_endpoint(_endpoint_path: str, _endpoint_method: Callable):
+            summary = f"Call auxiliary endpoint: {_endpoint_path}"
             description = "Call auxiliary endpoint"
-            endpoint_docs = inspect.getdoc(endpoint_method)
+            endpoint_docs = inspect.getdoc(_endpoint_method)
             if endpoint_docs:
                 description = f"Call auxiliary endpoint: {endpoint_docs}"
 
-            @api.post(
-                endpoint_path,
+            @options.api.post(
+                _endpoint_path,
                 operation_id=f'auxiliary_endpoint_{endpoint_name}',
                 summary=summary,
                 description=description,
             )
-            def _auxiliary_endpoint(
-                payload: Dict[str, Any] = Body(default=example_input),
-            ):
-                metric_requests_started.inc()
-                metric_endpoint_requests_started.labels(endpoint=endpoint_path).inc()
-                start_time = time.time()
-                try:
-                    assert payload is not None, 'payload is empty'
-                    return endpoint_method(**payload)
-                except TypeError as e:
-                    metric_request_internal_errors.labels(endpoint=endpoint_path).inc()
-                    raise ValueError(f'failed to call a function: {e}')
-                except BaseException as e:
-                    metric_request_internal_errors.labels(endpoint=endpoint_path).inc()
-                    raise e
-                finally:
-                    metric_request_duration.labels(endpoint=endpoint_path).observe(time.time() - start_time)
-                    metric_requests_done.inc()
-                    metric_last_call_timestamp.set(time.time())
+            def _auxiliary_endpoint(payload: Dict[str, Any] = Body(default=example_input)) -> Any:
+                return _call_job_endpoint(_endpoint_method, _endpoint_path, payload, options)
 
         _add_endpoint(endpoint_path, endpoint_method)
-
         logger.info(f'configured auxiliary endpoint: {endpoint_path}')
+
+
+def _call_job_endpoint(
+    endpoint_method: Callable,
+    endpoint_path: str,
+    payload: Dict[str, Any],
+    options: EndpointOptions,
+) -> Any:
+    metric_requests_started.inc()
+    metric_endpoint_requests_started.labels(endpoint=endpoint_path).inc()
+    start_time = time.time()
+    try:
+        assert payload is not None, 'payload is empty'
+
+        def _endpoint_caller() -> Any:
+            return endpoint_method(**payload)
+
+        return options.concurrency_runner(_endpoint_caller)
+    except TypeError as e:
+        metric_request_internal_errors.labels(endpoint=endpoint_path).inc()
+        raise ValueError(f'failed to call a function: {e}')
+    except BaseException as e:
+        metric_request_internal_errors.labels(endpoint=endpoint_path).inc()
+        raise e
+    finally:
+        metric_request_duration.labels(endpoint=endpoint_path).observe(time.time() - start_time)
+        metric_requests_done.inc()
+        metric_last_call_timestamp.set(time.time())
 
 
 def _setup_static_endpoints(api: APIRouter, entrypoint: JobEntrypoint):
@@ -283,3 +299,32 @@ def _setup_request_context(entrypoint: JobEntrypoint, fastapi_app: FastAPI):
         response = await call_next(request)
         request_context.reset(request_id)
         return response
+
+
+def jobtype_extra_int(jobtype_extra: Dict[str, Any], field_name: str) -> Optional[int]:
+    str_val = jobtype_extra.get(field_name)
+    if str_val is None:
+        return None
+    assert str_val.isdigit(), f'Expected integer in {field_name}, but got: {str_val}'
+    return int(str_val)
+
+
+def make_concurrency_runner(options: EndpointOptions) -> Callable[[Callable[..., Any]], Any]:
+    max_concurrency: Optional[int] = jobtype_extra_int(options.jobtype_extra, 'max_concurrency')
+    if not max_concurrency:
+        return lambda f: f()
+    max_concurrency_queue: Optional[int] = jobtype_extra_int(options.jobtype_extra, 'max_concurrency_queue')
+    concurrency_semaphore = threading.BoundedSemaphore(value=max_concurrency)
+
+    def concurrency_wrapper(f: Callable[..., Any]) -> Any:
+        queue_size: int = options.active_requests_counter.value - max_concurrency
+        if max_concurrency_queue is not None and queue_size >= max_concurrency_queue:
+            raise HTTPException(503, 'too many requests waiting in a queue')  # Service Unavailable
+        try:
+            options.active_requests_counter.inc()
+            with concurrency_semaphore:
+                return f()
+        finally:
+            options.active_requests_counter.dec()
+
+    return concurrency_wrapper

--- a/src/python_wrapper/racetrack_job_wrapper/concurrency.py
+++ b/src/python_wrapper/racetrack_job_wrapper/concurrency.py
@@ -1,0 +1,25 @@
+import threading
+
+
+class AtomicInteger:
+    def __init__(self, value=0):
+        self._value = int(value)
+        self._lock = threading.Lock()
+
+    def inc(self, d=1):
+        with self._lock:
+            self._value += int(d)
+            return self._value
+
+    def dec(self, d=1):
+        return self.inc(-d)
+
+    @property
+    def value(self):
+        with self._lock:
+            return self._value
+
+    @value.setter
+    def value(self, v):
+        with self._lock:
+            self._value = int(v)

--- a/src/python_wrapper/racetrack_job_wrapper/entrypoint.py
+++ b/src/python_wrapper/racetrack_job_wrapper/entrypoint.py
@@ -61,21 +61,6 @@ class JobEntrypoint(ABC):
         return []
 
 
-def perform_entrypoint(entrypoint: JobEntrypoint, payload: Dict[str, Any]) -> Dict:
-    """Call model/service main action"""
-    if entrypoint is None:
-        raise ValueError('undefined entrypoint')
-
-    if not hasattr(entrypoint, 'perform'):
-        raise ValueError("entrypoint doesn't have 'perform' method implemented")
-
-    try:
-        output = entrypoint.perform(**payload)
-    except TypeError as e:
-        raise ValueError(f'failed to call a function: {e}')
-    return output
-
-
 def list_entrypoint_parameters(entrypoint: JobEntrypoint) -> List[Dict]:
     """Inspect entrypoint function and return names, default values, types of all function's parameters"""
     if not hasattr(entrypoint, 'perform'):

--- a/src/python_wrapper/racetrack_job_wrapper/response.py
+++ b/src/python_wrapper/racetrack_job_wrapper/response.py
@@ -1,30 +1,14 @@
-from racetrack_commons.api.response import ResponseJSONEncoder, register_response_json_encoder
+from typing import Any
 
-from fastapi.encoders import ENCODERS_BY_TYPE
-
-
-class JobJSONEncoder(ResponseJSONEncoder):
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-
-        try:
-            import numpy as np
-
-            self.numpy_array = np.ndarray
-        except ModuleNotFoundError:
-            self.numpy_array = None
-
-    def default(self, o):
-        if self.numpy_array is not None and isinstance(o, self.numpy_array):
-            return o.tolist()
-        return super().default(o)
+from racetrack_client.utils.datamodel import convert_to_json_serializable
 
 
-def register_job_json_encoder():
-    register_response_json_encoder()
-
+def to_json_serializable(obj: Any) -> Any:
     try:
         import numpy as np
-        ENCODERS_BY_TYPE[np.ndarray] = lambda o: o.tolist()
+        if isinstance(obj, np.ndarray):
+            return convert_to_json_serializable(obj.tolist())
     except ModuleNotFoundError:
         pass
+
+    return convert_to_json_serializable(obj)


### PR DESCRIPTION
### Added
Maximum number of concurrent requests can be limited by `jobtype_extra.max_concurrency` field:
By default, concurrent requests are unlimited. Setting `max_concurrency` to `1` will make the job
process requests one by one. Overdue requests will be queued and processed in order.

Having such concurrency limits may cause some requests to wait in a queue.
If a throughput is higher than the job can handle, the queue will grow indefinitely.
To prevent that, you can also set `jobtype_extra.max_concurrency_queue` to limit the queue size.
When the queue is full, the job will return `429 Too Many Requests` status code.

Example (1 request at a time, with up to 10 requests waiting in a queue):
```yaml
jobtype_extra:
  max_concurrency: 1
  max_concurrency_queue: 10
```

Without this setting, FastAPI uses a threadpool of 40 threads internally to handle requests using non-async endpoints.
FastAPI uses Startlette's concurrency support to run requests in a threadpool. Starlette uses anyio, which in turn [has 40 as the default](https://anyio.readthedocs.io/en/stable/threads.html#adjusting-the-default-maximum-worker-thread-count)